### PR TITLE
sort by airtable view order

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,7 @@ const App = () => {
 
   const fetchData = async () => {
     try {
-      const response = await fetch(`https://api.airtable.com/v0/${import.meta.env.VITE_AIRTABLE_BASE_ID}/${import.meta.env.VITE_TABLE_NAME}?view=Grid%20view`, {
+      const response = await fetch(`https://api.airtable.com/v0/${import.meta.env.VITE_AIRTABLE_BASE_ID}/${import.meta.env.VITE_TABLE_NAME}?view=Grid%20view&sort[0][field]=Title&sort[0][direction]=asc`, {
       method: 'GET',
       headers: {
         Authorization:`Bearer ${import.meta.env.VITE_AIRTABLE_API_TOKEN}`, 
@@ -23,13 +23,13 @@ const App = () => {
     });
 
     if (!response.ok) {
-      throw new Error(`Error: ${response.status}`);
+      throw new Error(`Error: ${response.status} - ${response.statusText}`);
     }
 
     const data = await response.json();
 
     const todos = data.records.map((record) => ({
-      title: record.fields.title,
+      title: record.fields.Title,
       id: record.id,
     }));
 
@@ -40,7 +40,7 @@ const App = () => {
     setIsLoading(false);
 
   } catch (error) {
-    console.error('Fetch error: ${error.message}');
+    console.error(`Fetch error: ${error.message}`);
     setIsLoading(false);
   }
 };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,7 +29,7 @@ const App = () => {
     const data = await response.json();
 
     const todos = data.records.map((record) => ({
-      title: record.fields.Title,
+      title: record.fields.title,
       id: record.id,
     }));
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,7 @@ const App = () => {
 
   const fetchData = async () => {
     try {
-      const response = await fetch(`https://api.airtable.com/v0/${import.meta.env.VITE_AIRTABLE_BASE_ID}/${import.meta.env.VITE_TABLE_NAME}`, {
+      const response = await fetch(`https://api.airtable.com/v0/${import.meta.env.VITE_AIRTABLE_BASE_ID}/${import.meta.env.VITE_TABLE_NAME}?view=viwsK8prcfdGeQ2fO`, {
       method: 'GET',
       headers: {
         Authorization:`Bearer ${import.meta.env.VITE_AIRTABLE_API_TOKEN}`, 
@@ -27,7 +27,7 @@ const App = () => {
     }
 
     const data = await response.json();
-    
+
     const todos = data.records.map((record) => ({
       title: record.fields.title,
       id: record.id,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,7 @@ const App = () => {
 
   const fetchData = async () => {
     try {
-      const response = await fetch(`https://api.airtable.com/v0/${import.meta.env.VITE_AIRTABLE_BASE_ID}/${import.meta.env.VITE_TABLE_NAME}?view=Grid%20view&sort[0][field]=Title&sort[0][direction]=asc`, {
+      const response = await fetch(`https://api.airtable.com/v0/${import.meta.env.VITE_AIRTABLE_BASE_ID}/${import.meta.env.VITE_TABLE_NAME}?view=Grid%20view`, {
       method: 'GET',
       headers: {
         Authorization:`Bearer ${import.meta.env.VITE_AIRTABLE_API_TOKEN}`, 
@@ -33,10 +33,15 @@ const App = () => {
       id: record.id,
     }));
 
-    
-    console.log(todos);
+    const sortedTodos = todos.sort((a, b) => {
+      const titleA = (a.Title || "").toLowerCase();
+      const titleB = (b.Title || "").toLowerCase();
+      return titleA.localeCompare(titleB);
+});
 
-    setTodoList(todos);
+    console.log(sortedTodos);
+
+    setTodoList(sortedTodos);
     setIsLoading(false);
 
   } catch (error) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,8 +34,8 @@ const App = () => {
     }));
 
     const sortedTodos = todos.sort((a, b) => {
-      const titleA = (a.Title || "").toLowerCase();
-      const titleB = (b.Title || "").toLowerCase();
+      const titleA = (a.title || "").toLowerCase();
+      const titleB = (b.title || "").toLowerCase();
       return titleA.localeCompare(titleB);
 });
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,7 @@ const App = () => {
 
   const fetchData = async () => {
     try {
-      const response = await fetch(`https://api.airtable.com/v0/${import.meta.env.VITE_AIRTABLE_BASE_ID}/${import.meta.env.VITE_TABLE_NAME}?view=viwsK8prcfdGeQ2fO`, {
+      const response = await fetch(`https://api.airtable.com/v0/${import.meta.env.VITE_AIRTABLE_BASE_ID}/${import.meta.env.VITE_TABLE_NAME}?view=Grid%20view`, {
       method: 'GET',
       headers: {
         Authorization:`Bearer ${import.meta.env.VITE_AIRTABLE_API_TOKEN}`, 
@@ -32,6 +32,7 @@ const App = () => {
       title: record.fields.title,
       id: record.id,
     }));
+
     
     console.log(todos);
 

--- a/src/components/TodoList.jsx
+++ b/src/components/TodoList.jsx
@@ -19,16 +19,11 @@ const TodoList = ({ todoList, onRemoveTodo }) => {
   );
 };
 
-// TodoList.propTypes = {
-//   todoList: PropTypes.object.isRequired,
-//   onRemoveTodo: PropTypes.func.isRequired,
-// };
-
 TodoList.propTypes = {
   todoList: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-      title: PropTypes.string.isRequired,
+      title: PropTypes.string,
     })
   ).isRequired,
   onRemoveTodo: PropTypes.func.isRequired,


### PR DESCRIPTION
✅ Modified the Airtable API fetch request (the order of records matches the order defined in Airtable Grid view).
✅ Appended query parameters (view=Grid%20view) to the API URL to fetch records in the same order in Airtable.
✅ Verified that the list items in the app now appear in alphabetical order as expected.